### PR TITLE
Set the accept header to json for the token_url request

### DIFF
--- a/src/access.lua
+++ b/src/access.lua
@@ -143,6 +143,7 @@ function handle_callback( conf, callback_url )
             body = "grant_type=authorization_code&client_id=" .. conf.client_id .. "&client_secret=" .. conf.client_secret .. "&code=" .. args.code .. "&redirect_uri=" .. callback_url,
             headers = {
               ["Content-Type"] = "application/x-www-form-urlencoded",
+              ["Accept"] = "application/json",
             }
         })
 


### PR DESCRIPTION
In order to use GitHub as the OAuth 3rd party, the token_url request needs to send the `Accept` header with `application/json`. Otherwise, it returns the body in form-encoded format and the plugin is unable to parse it.